### PR TITLE
Add command-line option to ignore comments

### DIFF
--- a/pinpoint.c
+++ b/pinpoint.c
@@ -113,6 +113,7 @@ gboolean  pp_fullscreen      = FALSE;
 gboolean  pp_maximized       = FALSE;
 gboolean  pp_speakermode     = FALSE;
 gboolean  pp_rehearse        = FALSE;
+gboolean  pp_ignore_comments = FALSE;
 char     *pp_camera_device   = NULL;
 
 static GOptionEntry entries[] =
@@ -128,6 +129,8 @@ static GOptionEntry entries[] =
     "Show speakermode window", NULL},
     { "rehearse", 'r', 0, G_OPTION_ARG_NONE, &pp_rehearse,
     "Rehearse timings", NULL},
+    { "ignore-comments", 'i', 0, G_OPTION_ARG_NONE, &pp_ignore_comments,
+    "don't show comments", NULL},
     { "output", 'o', 0, G_OPTION_ARG_STRING, &pp_output_filename,
       "Output presentation to FILE\n"
 "                                         (formats supported: pdf)", "FILE" },
@@ -949,7 +952,7 @@ pp_parse_slides (PinPointRenderer *renderer,
               }
             break;
         case '#': /* comment */
-          if (startofline)
+          if (startofline && ! pp_ignore_comments)
             {
               const char *end = p + 1;
               while (*end != '\n' && *end != '\0')


### PR DESCRIPTION
With '-i' or '--ignore-comments', pinpoint will not show comments.

This is useful when you have to present a PDF version on a machine
without pinpoint (of which there are a shocking number).  The default
PDF output includes the comments as notes on interstitial pages, which
breaks up the flow and is possibly embarrassing.

It is also possible to use -i in speaker mode, in the strange case
that you want to see imminent slides and the time but not your notes.

Signed-off-by: Douglas Bagnall <douglas@paradise.net.nz>